### PR TITLE
Update ROBOSID.yaml and added STOCK.yaml

### DIFF
--- a/packages/ROBOSID.yaml
+++ b/packages/ROBOSID.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'ROBOSID'
 version: '1.8a'
-release: 2
+release: 1
 summary: 'Plays SID music files using OPL4 and/or Playsoniq'
 author: 'Marco Blom (ToriHino)'
 package_author: 'ToriHino'

--- a/packages/ROBOSID.yaml
+++ b/packages/ROBOSID.yaml
@@ -1,15 +1,16 @@
 ---
 name: 'ROBOSID'
-version: '1.18a'
-release: 1
+version: '1.8a'
+release: 2
 summary: 'Plays SID music files using OPL4 and/or Playsoniq'
 author: 'Marco Blom (ToriHino)'
 package_author: 'ToriHino'
-license: 'BSD-2-Clause'
+license: 'Public domain'
 category: 'Sound'
 system: 'MSX2'
 requirements:
   - 'MSX-DOS2'
+  - 'OPL4'
 url: 'https://www.msx.org/downloads/robosid'
 description: |
   RoboSID plays SID music files using the OPL4 (for example MoonSound) or Playsoniq, emulating both the 6510 cpu and SID chip used in the C64. It is limited to PSID files for both PAL and NTSC, RSID files are not supported. An MSX2 with DOS2 and 128KB at least is needed. Note that some songs are too much for the regular MSX2 and for those a faster MSX is required. 
@@ -44,3 +45,5 @@ build: |
 changelog: |
   - 1.18a-1 2018-11-20
     - First release
+  - 1.8a-2 2018-11-20
+    - Fixed version number, license type and added OPL4 requirement

--- a/packages/STOCK.yaml
+++ b/packages/STOCK.yaml
@@ -1,0 +1,29 @@
+---
+name: 'STOCK'
+version: '1.0'
+release: 1
+summary: 'Play with up to 3 players or against your MSX on the stock market'
+author: 'ToriHino'
+package_author: 'ToriHino'
+license: 'Public domain'
+category: 'Games'
+system: 'MSX'
+requirements:
+  - 'MSX-DOS2'
+url: 'https://www.msx.org/forum/msx-talk/development/stock-exchange-game-in-msx-c'
+description: |
+  Roll the dice, make strategic choices and try to beat the other players by being the first to earn a $100 in cash.
+  
+  You can play against your MSX or up to two other human players.
+  
+  The game is totally written in ASCII MSX-C v1.2 and based on an old basic listing published in the dutch MSX Computer Magazine.
+installdir: '\STOCK'
+files:
+  - stock.zip: 'http://torihino.nl/msx/stock.zip'
+build: |
+  mkdir -p package/
+  unzip stock.zip
+  mv STOCK.COM package/
+changelog: |
+  - 1.0-1 2018-11-26
+      - First release

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -74,6 +74,7 @@ allowed_requirements = [
     "MSX-DOS2",
     "MSX-DOS",
     "SCC",
+    "OPL4",
     "ROM",
     "MSX-MUSIC",
     "MSX-AUDIO",


### PR DESCRIPTION
Although the zip of ROBOSID is named 1.18a it actually contains 1.8a.