### PR TITLE
Adds openmsx args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean test emulator
 DOCKER = docker run -it --rm -u $$(id -u) -v $$(pwd):/usr/src fr3nd/msxhub-packages:5
-
+OPENMSX_ARGS ?= -machine "Boosted_MSXturboR_with_IDE" -ext msxdos2
 ALL = $(subst .yaml,,$(subst packages/,,$(wildcard packages/*.yaml)))
 ALL_ZIP = $(subst .yaml,.zip,$(subst packages/,,$(wildcard packages/*.yaml)))
 
@@ -19,7 +19,7 @@ test:
 	$(DOCKER) pytest-3 -v
 
 emulator:
-	openmsx -machine "Boosted_MSXturboR_with_IDE" -ext msxdos2 -script emulation/boot.tcl
+	openmsx $(OPENMSX_ARGS) -script emulation/boot.tcl
 
 clean:
 	rm -rf package DSK.dsk dsk/files files

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,6 +1,6 @@
 .PHONY: clean test emulator
 DOCKER = docker run -it --rm -v "%cd%":/usr/src fr3nd/msxhub-packages:4
-
+OPENMSX_ARGS ?= -machine "Boosted_MSXturboR_with_IDE" -ext msxdos2
 SHELL=cmd
 
 ALL = $(subst .yaml,,$(subst packages/,,$(wildcard packages/*.yaml)))
@@ -19,7 +19,7 @@ test:
 	$(DOCKER) pytest-3 -v
 
 emulator:
-	openmsx -machine "Boosted_MSXturboR_with_IDE" -ext msxdos2 -script emulation/boot.tcl
+	openmsx $(OPENMSX_ARGS) -script emulation/boot.tcl
 
 clean:
 	rmdir files /s /q

--- a/emulation/boot.tcl
+++ b/emulation/boot.tcl
@@ -1,18 +1,20 @@
 proc wait_until_boot {} {
-  global speed
-
-  if {[string first "BOOT COMPLETED" [get_screen]] >= 0} {
-    set speed 100
-  } else {
+  global throttle
+  set boot_done -1
+  if {[catch {set boot_done [string first "BOOT COMPLETED" [get_screen]]} err_msg]} {
+    puts stderr "warning: $err_msg"
+  }
+  if {$boot_done == -1} {
     after time 5 wait_until_boot
+  } else {
+    set throttle on
   }
 }
 
-diskmanipulator create DSK.dsk 32m 32m 32m 32m
+diskmanipulator create DSK.dsk 32m
 hda DSK.dsk
-diskmanipulator import hda1 ./dsk/
+diskmanipulator import hda ./dsk/
 
 set save_settings_on_exit off
-set speed 9999
-set fullspeedwhenloading on
-wait_until_boot
+set throttle off
+after realtime 1 wait_until_boot


### PR DESCRIPTION
Addes support for local working openmsx machine configs like;
```OPENMSX_ARGS="-machine Philips_NMS_8250 -ext ram4mb -ext ide -ext video9000" make emulator```

And added small fix for boot.tcl because when adding -ext ram4mb  i got this warning;
`warning: Screen mode 6 not supported`
And speed would never be set to normal.