### PR TITLE
Update TELNET.yaml

### DIFF
--- a/packages/TELNET.yaml
+++ b/packages/TELNET.yaml
@@ -32,7 +32,7 @@ description: |
     YMODEM-G, including file batch in YMODEM/YMODEM-G
 installdir: '\TELNET'
 files:
-  - TELNET.zip: 'https://github.com/ducasp/MSX-Development/raw/828d6f7ff8e276c32d55fe5e4fb91f23c23a8e91/UNAPI/TELNET/BINARY_PACK/TELNET.zip'
+  - TELNET.zip: 'https://github.com/ducasp/MSX-Development/blob/4af024794c611bb0b179658d9560f43c3fd87248/UNAPI/TELNET/BINARY_PACK/TELNET.zip'
 build: |
   mkdir -p package/
   unzip TELNET.zip -d package

--- a/packages/TELNET.yaml
+++ b/packages/TELNET.yaml
@@ -1,51 +1,46 @@
 ---
 name: 'TELNET'
-version: '1.10.0'
+version: '1.20.0'
 release: 1
 summary: 'Fast ANSI compatible TELNET client'
 author: 'Oduvaldo Pavan Junior'
 package_author: 'Carles Amigó (fr3nd)'
 license: 'GPL-3.0'
 category: 'Internet'
-system: 'MSX2'
+system: 'MSX'
 requirements:
   - 'MSX-DOS2'
 url: 'https://github.com/ducasp/MSX-Development/tree/master/UNAPI/TELNET'
 description: |
-  It is a TELNET client that allow you to connect to a TELNET server and interact
-  with it. If used along with MEMMAN and JANSI it will be able to receive and
-  show ANSI escape codes / colors. How is it different than TCPCON?
+  This is a TELNET client that allow you to connect to a TELNET server / BBSs
+  and interact with it. If an MSX2 or better is used, it will be able to
+  receive and show ANSI escape codes / colors. It should be MSX1 friendly as
+  long as your UNAPI adapter is compatible with MSX1.
   
-    - It implement TELNET negotiations, as such, echo is used as the other end
-      requests (no need to turn on or off manually), tell terminal type (Dumb
-      if JANSI is not running or xterm 16 colors otherwise), tell window size
-      as 80x24 if JANSI is not running or 80x25 otherwise). Also will respond
-      to ANSI request to cursor position, some BBS's use this to detect if
-      terminal is ANSI capable (this is done only once or until enter is
-      pressed so performance is not impacted by analyzing it along with other
-      ANSI escape codes)
-    
-    - If using JANSI, ANSI capabilities are automatically detected by most BBSs
-    
-    - It will use MS-DOS character set, which allow seeing ANSI animations and
-      menus as they are.
-    
-    - It accesses JANSI directly instead of using JANSI built in hook into DOS
-      functions, also it will initialize JANSI if it is installed but screen
-      mode is not JANSI
-    
-    - Will send all data to be printed at once once it is received and not do
-      it byte per byte (and in case of JANSI uses DMPSTR function)
-    
-    - It supports receiving files through XMODEM CRC, XMODEM 1K CRC, YMODEM and
-      YMODEM-G, including file batch in YMODEM/YMODEM-G
+  - It implements telnet negotiations, as such, echo is used as the other end
+    requests (no need to turn on or off manually), tell terminal type (Dumb
+    if MSX1 or xterm 16 colors otherwise), tell window size as 40x24 (MSX1)
+    or 80x24 (MSX1 with external 80 columns adapter and screen set to 80
+    columns before executing this software) or 80x25 if MSX2 or better.
+  - If using MSX2 or better, ANSI capabilities are automatically detected by
+    most BBSs either by telnet negotiation of Window Size or responding to
+    ANSI request to cursor position (some BBS's use this to detect if
+    terminal is ANSI capable)
+  - If using MSX2 or better, it will use MS-DOS character set, which allow
+    seeing ANSI animations and menus as they are
+  - It supports receiving files through XMODEM CRC, XMODEM 1K CRC, YMODEM and
+    YMODEM-G, including file batch in YMODEM/YMODEM-G
 installdir: '\TELNET'
 files:
-  - TELNET_AND_JANSI.zip: 'https://github.com/ducasp/MSX-Development/raw/a765ce9b56058087553b0e0852a80b2f955abd9e/UNAPI/TELNET/BINARY_PACK/TELNET.zip'
+  - TELNET.zip: 'https://github.com/ducasp/MSX-Development/raw/828d6f7ff8e276c32d55fe5e4fb91f23c23a8e91/UNAPI/TELNET/BINARY_PACK/TELNET.zip'
 build: |
   mkdir -p package/
-  unzip TELNET_AND_JANSI.zip -d package
+  unzip TELNET.zip -d package
 changelog: |
+  - 1.20.0-1 2019-09-02
+    - Version 1.11
+  - 1.11.0-1 2019-08-30
+    - Version 1.11
   - 1.10.0-1 2019-08-29
     - Version 1.10
   - 1.0.0-1 2019-08-24


### PR DESCRIPTION
Version 1.20, now ANSI-DRV.bin is no longer distributed, a SDCC library has been created so anyone can use it in their SDCC projects... And it is a little bit faster as well. :) Now just the readme and the com file, no ansi-drv.bin file