### PR TITLE
Added TuNzIp and LHEXT to the packages

### DIFF
--- a/packages/LHEXT.yaml
+++ b/packages/LHEXT.yaml
@@ -12,8 +12,8 @@ requirements:
   - 'MSX-DOS'
 url: ''
 description: |
-LHext Version 1.33 Copyright (C) 1995 By Tomoya Iwata.
-All Rights' Reserved.
+  LHext Version 1.33 Copyright (C) 1995 By Tomoya Iwata.
+  All Rights' Reserved.
 
 installdir: '\LHEXT'
 files:

--- a/packages/LHEXT.yaml
+++ b/packages/LHEXT.yaml
@@ -6,7 +6,7 @@ summary: 'LZH decompression tool'
 author: 'Tomoya Iwata'
 package_author: 'Fubukimaru'
 license: 'Proprietary'
-category: 'Tools'
+category: 'Files'
 system: 'MSX'
 requirements:
   - 'MSX-DOS'

--- a/packages/LHEXT.yaml
+++ b/packages/LHEXT.yaml
@@ -22,15 +22,15 @@ description: |
   ∙ Supports -lh6-, and decompression of -lh5- is faster than PMext.
 
 
-  ● Operating environment
+  Operating environment
 
   Works with MSX-DOS (1).
 
-  -MSX-DOS (1) without mapper BIOS and -Lh6-
-  -lh7- cannot be decompressed. -lh5- can also be decompressed on this system.
+  - MSX-DOS (1) without mapper BIOS and -Lh6-
+     -lh7- cannot be decompressed. -lh5- can also be decompressed on this system.
 
 
-  ● Startup format
+  Startup format
 
   LHEXT [command] [archive name] [member name ..] [{/ |-} option ..]
 
@@ -53,7 +53,7 @@ description: |
   Uppercase and lowercase letters are not distinguished for any element.
 
 
-  ● Instruction
+  # Instruction
 
   [E (Extract) Extraction]
 
@@ -94,7 +94,7 @@ description: |
 
   (Example 6) A> LHEXT X LSIC330 * .EXE * .H / O
   Extract files with extensions EXE and H from LSIC330.LZH with directories
-	To do. At this time, the overwrite mode is set.
+    To do. At this time, the overwrite mode is set.
 
 
   [List of l (List)]
@@ -126,7 +126,7 @@ description: |
   Check all files in TESTPACK.LZH.
 
 
-  ● Option
+  # Option
 
   [/] O [|-] Overwrite mode specification]
 
@@ -157,7 +157,7 @@ description: |
   (Example 10-1) A> LHEXT /O-TEST.LZH
 
 
-  ● Compatible compression format
+  # Compatible compression format
   The following compression formats can be decompressed.
   -lh0- uncompressed format
   -lh1- Compressed with old LHarc.exe (MS-DOS) or LHA.COM (CP / M)
@@ -179,10 +179,10 @@ description: |
   In the above format, the list can be displayed with the l command even if decompression is not supported.
   Noh.
 
-  -Lhd- does not decompress (?) Unless it is an x ​​command.
+  -Lhd- does not decompress (?) Unless it is an x command.
 
 
-  ● Usage conditions
+  # Usage conditions
 
   This software is free software that does not give up copyright. Use freely within the following range
   It is fine to use.
@@ -198,11 +198,11 @@ description: |
   If the above is observed, no permission is required for reprinting.
 
 
-  ● Thanks
+  # Thanks
 
     LHA.EXE LHARC.EXE is free software by Eiyoshi Yoshizaki.
 
-  作成 For the creation of this software, the source of Mr. Eiyoshi Yoshizaki and the source of C language of Mr. D
+  For the creation of this software, the source of Mr. Eiyoshi Yoshizaki and the source of C language of Mr. D
   Did.
 
   Please release useful software for free and release the source for free.
@@ -210,7 +210,7 @@ description: |
   Would like to express my gratitude on this occasion (although it will not reach (^^;)
 
 
-  ● Contact information
+  # Contact information
 
     [e-mail]
 

--- a/packages/LHEXT.yaml
+++ b/packages/LHEXT.yaml
@@ -1,0 +1,28 @@
+---
+name: 'LHEXT'
+version: '1.34'
+release: 1
+summary: 'LZH decompression tool'
+author: 'Tomoya Iwata'
+package_author: 'Fubukimaru'
+license: 'Proprietary'
+category: 'Tools'
+system: 'MSX'
+requirements:
+  - 'MSX-DOS'
+url: ''
+description: |
+LHext Version 1.33 Copyright (C) 1995 By Tomoya Iwata.
+All Rights' Reserved.
+
+installdir: '\LHEXT'
+files:
+  - lhext134.lzh: 'http://members.ziggo.nl/the.incantation/dload/lhext134.lzh'
+build: |
+  mkdir -p package/
+  lha x lhext134.lzh
+  mv LHEXT.COM package/lhext.com
+  mv LHEXT.DOC package/lhext.doc
+changelog: |
+  - 1.34 2019-10-13
+    - First release

--- a/packages/LHEXT.yaml
+++ b/packages/LHEXT.yaml
@@ -12,8 +12,232 @@ requirements:
   - 'MSX-DOS'
 url: ''
 description: |
-  LHext Version 1.33 Copyright (C) 1995 By Tomoya Iwata.
-  All Rights' Reserved.
+  For MSX-DOS. LZH extractor LHext
+
+  LHext Version 1.33
+  Copyright (C) 1995 by KYOJU
+
+
+  This is a tool for decompressing .LZH files with MSX-DOS.
+  ∙ Supports -lh6-, and decompression of -lh5- is faster than PMext.
+
+
+  ● Operating environment
+
+  Works with MSX-DOS (1).
+
+  -MSX-DOS (1) without mapper BIOS and -Lh6-
+  -lh7- cannot be decompressed. -lh5- can also be decompressed on this system.
+
+
+  ● Startup format
+
+  LHEXT [command] [archive name] [member name ..] [{/ |-} option ..]
+
+  [Instruction] Specify the operation of LHext.
+  If omitted, the e command is selected.
+  Usually it must be written at the beginning without options, but / or
+  -You can write anywhere in the form by prefixing it.
+
+  [[Archive name] Specify the archive file name.
+  If the extension is omitted, .LZH is assumed.
+  If you do not specify the archive name, a help message appears.
+
+  [Member Name] Specify what you want to process among the files stored in the archive.
+  You can use wildcards. You can specify more than one.
+  Omitting the member name is the same as specifying *. *.
+  
+  The [Option] Used for operation settings.
+  Options can appear anywhere in the form.
+
+  Uppercase and lowercase letters are not distinguished for any element.
+
+
+  ● Instruction
+
+  [E (Extract) Extraction]
+
+  Decompress the specified member from the archive.
+
+  If there is a new file with the same name and a new time stamp, it will normally be skipped.
+  However, it can be overwritten with the / O option.
+
+  ∙ You can specify the decompression destination drive with the / D <d> option. For example, specify / DH
+  Then unzip to H drive.
+
+  If the command is omitted, this e-command will be used.
+
+  (Example 1) A> LHEXT KJFOS173
+  Unzip all files in KJFOS173.LZH.
+
+  (Example 2) A> LHEXT KJFOS173 * .DOC * .COM
+  Unzip the file with the extension DOC and the file with the extension COM in KJFOS173.LZH.
+
+  (Example 3) A> LHEXT KJFOS173 KJFOS.COM / O
+  Unzip KJFOS.COM in overwrite mode from KJFOS173.LZH.
+
+  (Example 4) A> LHEXT / DH EX K *. *
+  Unzip the file whose name begins with K in EX.LZH to drive H.
+
+
+  [X (eXtract with directory) Unzip with directory]
+
+  If the path name is recorded in the archive, unzip it to that path. Digging directory
+  If you can, dig.
+
+  This is valid only for MSX-DOS2, and is the same as the e command for MSX-DOS1.
+
+  ∙ The / O and / D options are valid as with the e command.
+
+  (Example 5) A> LHEXT X LSIC330
+  Unzip LSIC330.LZH with directory.
+
+  (Example 6) A> LHEXT X LSIC330 * .EXE * .H / O
+  Extract files with extensions EXE and H from LSIC330.LZH with directories
+	To do. At this time, the overwrite mode is set.
+
+
+  [List of l (List)]
+
+  Displays a list of members in the archive.
+  ”“ ”Is displayed at the beginning of the file for members whose path is also recorded.
+
+  This display can be redirected even in DOS1.
+
+  (Example 7) A> LHEXT L TEST
+  Displays all files in TEST.LZH.
+
+  (Example 8) A> LHEXT LSIC330 * .OBJ / L> LSIC_OBJ.LST
+  A list of files with the extension OBJ in LSIC330.LZH is called LSIC_OBJ.LST
+  Export to
+
+
+  [V (View) list]
+
+  Displays a list of members in the archive.
+  ∙ Similar to the l command, but if a path is recorded, it is also displayed.  
+
+  [T (Test) inspection]
+
+  Test the archive. By checking the CRC of the files in the archive,
+  Inspect the file for corruption.
+
+  (Example 9) A> LHEXT T TESTPACK
+  Check all files in TESTPACK.LZH.
+
+
+  ● Option
+
+  [/] O [|-] Overwrite mode specification]
+
+  When decompressing, specify whether to overwrite when the same name file exists in the decompression destination.
+  Valid with the e command and x command.
+
+  If / O is overwritten, / O- is skipped.
+  If you omit [|-] and just use / O, the current status is reversed. The startup state is / O-.
+
+
+  [/ D <drive> Extraction drive specification]
+
+  Set the drive to decompress to <drive>.
+  Valid with the e command and x command.
+
+
+  Environment variable LHEXT
+
+  ∙ You can write default commands and options in the environment variable LHEXT. However
+  It is valid only for DOS2.
+
+  (Example 10) A> SET LHEXT = X / O
+
+  If you do this, if you omit the command, the x command will be selected and the / O option will always be used.
+  Will start.
+  In this state, specify / O- on the command line to start with the / O option removed.
+
+  (Example 10-1) A> LHEXT /O-TEST.LZH
+
+
+  ● Compatible compression format
+  The following compression formats can be decompressed.
+  -lh0- uncompressed format
+  -lh1- Compressed with old LHarc.exe (MS-DOS) or LHA.COM (CP / M)
+  -lh5- Compressed with LHa.exe (MS-DOS)
+  -lh6- Compressed with the new version of LHA (MS-DOS) under trial (as of March 6, 95)
+  -lhd- An empty directory that can be created with the new version of LHA (MS-DOS)
+
+  -lh4- -lh5- is half the dictionary size. However, “deem” to be the same as -lh5-
+  Can also be used, so it is actually -lh4-, but it may be recorded as -lh5-
+  There is.
+  -lh7- Although there is a standard in the new version LHA (MS-DOS), it is still compressed in this format
+  It seems you can't.
+
+  The following compression formats are not supported
+  -lh2- -lh3- -lzs- -lz5- -pm1- -pm2-
+
+  Compressed format can be confirmed with l command. l If the command cannot display the list
+  Is a library that doesn't support in the first place (^^;
+  In the above format, the list can be displayed with the l command even if decompression is not supported.
+  Noh.
+
+  -Lhd- does not decompress (?) Unless it is an x ​​command.
+
+
+  ● Usage conditions
+
+  This software is free software that does not give up copyright. Use freely within the following range
+  It is fine to use.
+
+  o Do not change the copyright notice.
+  o Distribute with this document.
+  o Even if a failure occurs as a result of operating this program, it is not guaranteed.
+  o The author is not obligated to correct any deficiencies in this program.
+  o When using it in a product, display the copyright notice in at least one place.
+  o When distributing a modified version, the name of the reorganizer (handle) and any changes
+  Please indicate that it is.
+
+  If the above is observed, no permission is required for reprinting.
+
+
+  ● Thanks
+
+    LHA.EXE LHARC.EXE is free software by Eiyoshi Yoshizaki.
+
+  作成 For the creation of this software, the source of Mr. Eiyoshi Yoshizaki and the source of C language of Mr. D
+  Did.
+
+  Please release useful software for free and release the source for free.
+  To Mr. Yoshizaki, Mr. D Bo who released the source in the form of C language that is easy to understand
+  Would like to express my gratitude on this occasion (although it will not reach (^^;)
+
+
+  ● Contact information
+
+    [e-mail]
+
+            NIFTY-Serve TBE03371
+            PC-VAN CWJ48302 today
+            KONEMI-Station kon027 today
+            Illusion City KYOJU
+            PP-NET KYOJU
+
+    [Mail] (Use only if it is difficult to contact)
+
+      606, Kyoto City, Sakyo Ward, Yoshida Kaguraokacho 3-2
+      Green Heights Tajima 212
+                                                   Tomoya Iwata
+
+  Versions:
+     1995/1/21 Ver1.00 BGM :: pearl jam "vitalogy"
+     1995/1/27 Ver1.11 BGM :: SOUNDGARDEN "SUPERUNKNOWN"
+     1995/1/28 Ver1.12 BGM :: SOUNDGARDEN "SUPERUNKNOWN"
+     1995/2/6 Ver1.14 BGM :: GUNSN 'ROSES "USE YOUR ILLUSION II"
+     1995/2/9 Ver1.15 BGM :: U2 "WAR"
+     1995/3/6 Ver1.30 BGM :: PIXIES "SURFER ROSA"
+     1995/3/17 Ver1.33 BGM :: TAPE (ORIGINAL EDITION)
+
+     LHext Version 1.33 Copyright (C) 1995 By Tomoya Iwata.
+                     All Rights' Reserved.
+
 
 installdir: '\LHEXT'
 files:

--- a/packages/TUNZIP.yaml
+++ b/packages/TUNZIP.yaml
@@ -6,7 +6,7 @@ summary: 'TuNzIp, TNIs zip decompression tool decompression tool'
 author: 'Patriek Lesparre'
 package_author: 'Fubukimaru'
 license: 'Freeware'
-category: 'Tools'
+category: 'Files'
 system: 'MSX'
 requirements:
   - 'MSX-DOS'

--- a/packages/TUNZIP.yaml
+++ b/packages/TUNZIP.yaml
@@ -1,0 +1,33 @@
+---
+name: 'TUNZIP'
+version: '0.91'
+release: 1
+summary: 'TuNzIp, TNIs zip decompression tool decompression tool'
+author: 'Patriek Lesparre'
+package_author: 'Fubukimaru'
+license: 'Freeware'
+category: 'Tools'
+system: 'MSX'
+requirements:
+  - 'MSX-DOS'
+url: 'http://www.tni.nl/products/tunzip.html'
+description: |
+  TuNzIp is the first decompressor on MSX that works with the ubiquitous "deflate" algorithm. This allows you to compress ZIP files anywhere and decompress them on MSX running MSX-DOS2.
+
+  Compared to the LZH decompressor LHext, speed is similar when using a RAM disk, but TuNzIp beats LHext by 1.5 times when working with diskettes. Rather than brute-forcing more speed, it relies on smart algorithms that minimize the memory footprint, in order to facilitate integration in other programs.
+
+  Version 0.91 info:
+  Only supports ZIP files with filenames in 8.3 format (longer filenames will be cut off), and without subdirectory trees. Files are decompressed to the current working directory. Existing files are not overwritten. Broken/partial files are kept. Later versions will add support for longer filenames and subdirectories, as well as various commandline switches.
+
+  TuNzIp is written by Patriek Lesparre, (c) 2005-2015 by The New Image
+
+files:
+  - TuNzIp.zip: 'http://www.tni.nl/products/TuNzIp.zip'
+build: |
+  mkdir -p package/
+  unzip TuNzIp.zip
+  mv tunzip.com package/
+  mv tunzip.txt package/
+changelog: |
+  - 0.91 2019-10-13
+    - First release

--- a/packages/TUNZIP.yaml
+++ b/packages/TUNZIP.yaml
@@ -21,6 +21,7 @@ description: |
 
   TuNzIp is written by Patriek Lesparre, (c) 2005-2015 by The New Image
 
+installdir: '\TUNZIP'
 files:
   - TuNzIp.zip: 'http://www.tni.nl/products/TuNzIp.zip'
 build: |


### PR DESCRIPTION
Added both zip and lzh decompressors as packages.

LHEXT has copyright so it may be an issue on licensing. On the other hand TuNzIp is freeware as long as the documentation file is distributed with it (it is included).