### PR TITLE
New version of Telnet, 1.33

### DIFF
--- a/packages/INSTAGR8.yaml
+++ b/packages/INSTAGR8.yaml
@@ -19,7 +19,6 @@ description: |
   MSX-DOS client of InstaGR8 server has the advantage of not needing GR8NET,
   working on ObsoNet, Denyonet, SM-X WiFi, GR8NET and any other adapter for
   MSX that is TCP-IP UNAPI Compliant.
-	
   As it doesn't rely on GR8NET specific API, it is not possible to show the
   picture as fast as original Glufke program does. This is because GR8NET
   simply store the whole image in its own buffer and then transfer directly

--- a/packages/TELNET.yaml
+++ b/packages/TELNET.yaml
@@ -1,6 +1,6 @@
 ---
 name: 'TELNET'
-version: '1.32.0'
+version: '1.33.0'
 release: 1
 summary: 'Fast ANSI compatible TELNET client'
 author: 'Oduvaldo Pavan Junior'
@@ -32,11 +32,13 @@ description: |
     YMODEM-G, including file batch in YMODEM/YMODEM-G
 installdir: '\TELNET'
 files:
-  - TELNET.zip: 'https://github.com/ducasp/MSX-Development/raw/693736d3c55e056d85603b61ddf9dab2aa25a97b/UNAPI/TELNET/BINARY_PACK/TELNET.zip'
+  - TELNET.zip: 'https://github.com/ducasp/MSX-Development/raw/a07e9dc106f09dc2676b3eba601510cb34ec69e9/UNAPI/TELNET/BINARY_PACK/TELNET.zip'
 build: |
   mkdir -p package/
   unzip TELNET.zip -d package
 changelog: |
+  - 1.33.0-1 2020-09-14
+    - Version 1.33
   - 1.32.0-1 2020-05-03
     - Version 1.32
   - 1.31.0-1 2020-04-24


### PR DESCRIPTION
Hi Fr3nd,

New version of Telnet, fixed a few MSX1 related bugs as well as adding support to FOSSIL based Internet Adapters like Andrés Ortiz BadCat and working around an issue created by Synchronet on BBS's that have updated with their latest version that sends XTERM escape codes to terminals that have reported being ANSI only

Thanks!