### PR TITLE
Add omsxctl

### DIFF
--- a/packages/OMSXCTL.yaml
+++ b/packages/OMSXCTL.yaml
@@ -12,7 +12,7 @@ requirements:
   - 'MSX-DOS'
 url: 'https://code.distributedrebirth.love/arch-msx/omsxctl'
 description: |
-  OpenMSXConTroL is an utility to send control commands to openMSX from within the emulated msx.
+  OpenMSXConTroL is an utility to send control commands to openMSX(16.0 or higher) from within the emulated msx.
 installdir: '\OMSXCTL'
 files:
   - omsxctl-1.0.tar.gz: 'https://code.distributedrebirth.love/attachments/d704a675-fa4f-4cb3-8c54-b9626393f283'

--- a/packages/OMSXCTL.yaml
+++ b/packages/OMSXCTL.yaml
@@ -1,0 +1,28 @@
+---
+name: 'OMSXCTL'
+version: '1.0'
+release: 1
+summary: 'omsxctl'
+author: 'm9710797 and immetoo'
+package_author: 'immetoo'
+license: 'Unknown'
+category: 'Tools'
+system: 'MSX2'
+requirements:
+  - 'MSX-DOS'
+url: 'https://code.distributedrebirth.love/arch-msx/omsxctl'
+description: |
+  OpenMSXConTroL is an utility to send control commands to openMSX from within the emulated msx.
+installdir: '\OMSXCTL'
+files:
+  - omsxctl-1.0.tar.gz: 'https://code.distributedrebirth.love/attachments/d704a675-fa4f-4cb3-8c54-b9626393f283'
+build: |
+  mkdir -p package/
+  tar xvzf omsxctl-1.0.tar.gz
+  unix2dos omsxctl-1.0/usage.txt
+  mv omsxctl-1.0/omsxctl.com package/
+  mv omsxctl-1.0/omsxctl.tcl package/
+  mv omsxctl-1.0/usage.txt package/
+changelog: |
+  - 1.0-1 2020-11-17
+    - First release


### PR DESCRIPTION
Added omsxctl dos util for use within openMSX.

Main purpose is for scripting for example;
- wget this+dos+other deps from msxhub.com
- boot+run openMSX with bat file
- shutdown emulator (build/test pipeline step) from msxdos; 'omsxctl exit'

