### PR TITLE
Moon Rabbit gopher browser added

### DIFF
--- a/packages/MOONR.yaml
+++ b/packages/MOONR.yaml
@@ -1,0 +1,30 @@
+---
+name: 'MOONR'
+version: '0.01'
+release: 1
+summary: 'Moon Rabbit - gopher browser'
+author: 'Alexander Sharihin(Nihirash)'
+package_author: 'Alexander Sharihin(Nihirash)'
+license: 'Freeware'
+category: 'Internet'
+system: 'MSX2'
+requirements:
+  - 'MSX-DOS2'
+url: 'https://github.com/nihirash/moon-rabbit'
+description: |
+  Gopher browser for MSX2 compatible computers.
+  
+  It can browse gopher spaces(including text requests), open plain-text files, play PT3 track and download files
+installdir: '\MOONR'
+files:
+  - moonr.zip: 'https://github.com/nihirash/moon-rabbit/releases/download/%VERSION%/moonr.zip'
+build: |
+  mkdir -p package/
+  unzip moonr.zip
+  mv moonr.com package/
+  mv index.gph package/
+  mv font.bin package/
+  
+changelog: |
+  - "0.01"
+    - Initial version


### PR DESCRIPTION
I've made UnApi gopher browser for MSX2 and want publish it on HUB.

It uses my own license(https://github.com/nihirash/moon-rabbit/blob/main/LICENSE) but freeware here is ok(or replace to any license what have similar "spirit").