### PR TITLE
HUB - Update HUBG to v0.90

### DIFF
--- a/packages/HUB.yaml
+++ b/packages/HUB.yaml
@@ -1,6 +1,6 @@
 ---
 name: 'HUB'
-version: '1.0.5'
+version: '1.0.6'
 release: 1
 summary: 'Application to download and install software from the internet'
 author: 'Carles Amigó (fr3nd) and Oduvaldo Pavan Junior (Ducasp)'
@@ -25,7 +25,7 @@ description: |
 installdir: '\HUB'
 files:
   - hub.com: 'https://github.com/fr3nd/msxhub/releases/download/%VERSION%/hub.com'
-  - hubg.zip: 'https://github.com/ducasp/MSX-Development/raw/2e17f811169341642c131a8962caaad563fa122a/UNAPI/HUBG/BINARY_PACK/HUBG.zip'
+  - hubg.zip: 'https://github.com/ducasp/MSX-Development/raw/086120016e7bff85c47e72725c6ba67e37a706c3/UNAPI/HUBG/BINARY_PACK/HUBG.zip'
 build: |
   mkdir -p package/
   mv hub.com package/
@@ -33,6 +33,10 @@ build: |
   mv MANUAL.TXT package/HUBG.TXT
   mv HUBG.com package/
 changelog: |
+  - 1.0.6-1 2022-11-30
+    - New release
+    - HUBG updated to 0.90
+    - HUBG is now able to list all packages in game category :)
   - 1.0.5-1 2020-09-19
     - New release
     - HUBG updated to 0.80


### PR DESCRIPTION
@israelferrazaraujo was kind enough to update HUBG to dynamically allocate memory entries which extends the capability of packages in a given category (i.e. games now has 132 packages!) for more than 70, depending only on how much space of description each package uses. Now it is able to fully list the games category and you can retrieve any of the 132 entries there...